### PR TITLE
Fix syntax error in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,8 @@
 # William Leese <william.leese@meltwater.com>
 #
 class incron (
-  ensure = 'running',
-  manage_service = true,
+  $ensure = 'running',
+  $manage_service = true,
 ) {
 
   package {'incron': ensure => installed }


### PR DESCRIPTION
Add missing dollar signs to init.pp manifest, because puppet module would not install.

Change-Id: Ib9b666fd1a54eed6e1f96bd81d02d0a9e4ef1963
