### PR TITLE
Enable the service on reboot instead of only when puppet is run if the service is being managed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,15 @@ class incron (
   package {'incron': ensure => installed }
 
   if manage_service {
+    if $ensure == 'running' {
+      $enable = true
+    } else {
+      $enable = false
+    }
+
     service {'incrond': 
       ensure  => $ensure,
+      enable  => $enable,
       require => Package['incron']     
     }
   }


### PR DESCRIPTION
Currently if a box using this incron module is rebooted; incron will be stopped until puppet is run again. This will make the on-boot service enablement status follow the ensure => running/stopped/etc setting that already exists.