### PR TITLE
Fix issue on debian incron package installation where service name is `incron` instead of `incrond`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,14 +9,14 @@
 class incron (
   $ensure = 'running',
   $manage_service = true,
-) {
+) inherits incron::params {
 
   package {'incron': ensure => installed }
 
   if manage_service {
-    service {'incrond': 
+    service { $incron::params::service_name:
       ensure  => $ensure,
-      require => Package['incron']     
+      require => Package['incron']
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,22 @@
+# == Class: incron::params
+#
+# Defines defaults for the incron class. Params class should not be called
+# directly.
+#
+# === Authors
+#
+# Derek Tamsen <dtamsen@gmail.com>
+#
+class incron::params {
+
+  case $::osfamily {
+    'Debian': {
+      $service_name = 'incron'
+    }
+
+    default: {
+      $service_name = 'incrond'
+    }
+  }
+
+}


### PR DESCRIPTION
Add incron::params class to set the service name to `incron` for osfamily = debian. The service name defaults to `incrond` to maintain backwards compatibility. Resolves #6
- add params and define service name for Debian as incron and default to incrond for all other osfamilies
- remove trailing spaces on manifests/init.pp:19
