### PR TITLE
Fixes an issue where non-interactive runs fail

### DIFF
--- a/lib/puppet/provider/incron/parsed.rb
+++ b/lib/puppet/provider/incron/parsed.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :filetype => :flat) do
+Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "/var/spool/incron/root", :filetype => :flat) do
   commands :incrontab => "incrontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|


### PR DESCRIPTION
During non-interactive runs, the incron module would look for incrontab in /root (which is a directory) and yield the following error:
```
Could not prefetch incron provider 'incrontab': Puppet::Util::FileType::FileTypeFlat could not read root: Is a directory - root
Puppet::Util::FileType::FileTypeFlat could not read root: Is a directory - root
```
This patch fixes the behaviour by pointing to the actual location for the incrontab file.