### PR TITLE
Fix addind incron entry on first run

### DIFF
--- a/lib/puppet/provider/incron/parsed.rb
+++ b/lib/puppet/provider/incron/parsed.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "/var/spool/incron/root", :filetype => :flat) do
+Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :filetype => :flat) do
   commands :incrontab => "incrontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|

--- a/lib/puppet/provider/incron/parsed.rb
+++ b/lib/puppet/provider/incron/parsed.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "root", :filetype => :flat) do
+Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "/var/spool/incron/root", :filetype => :flat) do
   commands :incrontab => "incrontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|

--- a/lib/puppet/type/incron.rb
+++ b/lib/puppet/type/incron.rb
@@ -114,17 +114,11 @@ Puppet::Type.newtype(:incron) do
     is empty."
 
     defaultto {
-      if provider.is_a?(@resource.class.provider(:incrontab))
-        if val = @resource.should(:user)
-          return "/var/spool/incron/#{resource[:user]}" 
-        else
-          raise ArgumentError,
-            "You must provide a username with incrontab entries"
-        end 
-      elsif provider.class.ancestors.include?(Puppet::Provider::ParsedFile)
-        provider.class.default_target
+      if val = @resource.should(:user)
+        return "/var/spool/incron/#{resource[:user]}" 
       else
-        nil 
+        raise ArgumentError,
+          "You must provide a username with incrontab entries"
       end 
     }   
   end


### PR DESCRIPTION
Durring the first run of this module the incron type might not work because the incrontab command is not found. Usually puppet wait for the last moment to check this, but the check at the end of the type incron forces the check to be done earlier.
