### PR TITLE
Fix recreation of incrontab files on non-interactive runs

### DIFF
--- a/lib/puppet/provider/incron/parsed.rb
+++ b/lib/puppet/provider/incron/parsed.rb
@@ -1,6 +1,6 @@
 require 'puppet/provider/parsedfile'
 
-Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => ENV["USER"] || "/var/spool/incron/root", :filetype => :flat) do
+Puppet::Type.type(:incron).provide(:incrontab, :parent => Puppet::Provider::ParsedFile, :default_target => "/var/spool/incron/" + (ENV["USER"] || "root"), :filetype => :flat) do
   commands :incrontab => "incrontab"
 
   text_line :comment, :match => %r{^\s*#}, :post_parse => proc { |record|


### PR DESCRIPTION
On non-interactive runs, the incrontab files will be flushed due to wrong default_target parameter for the provider. The default_target parameter should be a path but user names was given instead.

```
Could not prefetch incron provider 'incrontab': Puppet::Util::FileType::FileTypeFlat could not read root: Is a directory - root
```

Commit 2e30399 didn't fully fix this issue.